### PR TITLE
fix: make OTR pages server-rendered for subdomain routing

### DIFF
--- a/src/pages/otr/authors/[slug].astro
+++ b/src/pages/otr/authors/[slug].astro
@@ -3,18 +3,14 @@ import OTRLayout from "@/layouts/OTRLayout.astro";
 import CardWrapper from "@/components/CardWrapper.astro";
 import OTRCard from "@/components/otr/OTRCard.astro";
 import { getCollection } from "astro:content";
-import { columnists } from "@/data/columnists";
+import { columnists, getColumnistBySlug } from "@/data/columnists";
 
-export const prerender = true;
+const { slug } = Astro.params;
+const columnist = getColumnistBySlug(slug!);
 
-export function getStaticPaths() {
-  return columnists.filter((c) => !c.hidden).map((columnist) => ({
-    params: { slug: columnist.slug },
-    props: { columnist },
-  }));
+if (!columnist || columnist.hidden) {
+  return Astro.redirect("/otr");
 }
-
-const { columnist } = Astro.props;
 
 const posts = await getCollection(
   "otr",

--- a/src/pages/otr/index.astro
+++ b/src/pages/otr/index.astro
@@ -6,8 +6,6 @@ import ColumnistCard from "@/components/otr/ColumnistCard.astro";
 import { getCollection } from "astro:content";
 import { columnists } from "@/data/columnists";
 
-export const prerender = true;
-
 const allPosts = await getCollection("otr");
 const sortedPosts = allPosts.sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()

--- a/src/pages/otr/posts/[slug].astro
+++ b/src/pages/otr/posts/[slug].astro
@@ -7,17 +7,14 @@ import OTRCard from "@/components/otr/OTRCard.astro";
 import { getCollection } from "astro:content";
 import { getColumnistBySlug } from "@/data/columnists";
 
-export const prerender = true;
+const { slug } = Astro.params;
+const allEntries = await getCollection("otr");
+const post = allEntries.find((p) => p.id === slug);
 
-export async function getStaticPaths() {
-  const posts = await getCollection("otr");
-  return posts.map((post) => ({
-    params: { slug: post.id },
-    props: { post },
-  }));
+if (!post) {
+  return Astro.redirect("/otr");
 }
 
-const { post } = Astro.props;
 const { Content } = await post.render();
 const columnist = getColumnistBySlug(post.data.author);
 const columnName = post.data.column || columnist?.columnName || "Column";


### PR DESCRIPTION
Prerendered pages are served as static assets by Cloudflare before the worker middleware runs, so the otr.herrerake.com rewrite never fires. Switching to server-rendered lets the middleware handle the rewrite.