### PR TITLE
Hide portfolio from navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,10 +14,10 @@ const links = [
     name: "About me",
     location: "/about",
   },
-  {
-    name: "Portfolio",
-    location: "/portfolio",
-  },
+  // {
+  //   name: "Portfolio",
+  //   location: "/portfolio",
+  // },
   {
     name: "Blog",
     location: "/blog",


### PR DESCRIPTION
## Summary
- Commented out the Portfolio link in the header navigation since the portfolio pages currently only contain placeholder/lorem ipsum content

## Test plan
- [ ] Verify the nav bar no longer shows "Portfolio"
- [ ] Confirm all other nav links (Home, About me, Blog, OTR) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)