### PR TITLE
fix: strip .mdx extension from content collection slugs

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -6,13 +6,14 @@ import { getTagLabel } from "@/data/tags";
 type Blog = CollectionEntry<"blog">;
 
 const { blog } = Astro.props as { blog: Blog };
+const slug = blog.id.replace(/\.mdx?$/, "");
 ---
 
 <a
-  href={`/blog/${blog.id}`}
+  href={`/blog/${slug}`}
   class="block w-full h-full bg-cover bg-center relative overflow-hidden rounded-3xl group"
   style={{ backgroundImage: `url(${blog.data.image.url})` }}
-  transition:name={`blog-card-${blog.id}`}
+  transition:name={`blog-card-${slug}`}
 >
   <div
     class="backdrop-brightness-50 group-hover:backdrop-brightness-[.35] transition-all w-full h-full p-6 sm:p-8 flex flex-col items-start justify-end"
@@ -39,7 +40,7 @@ const { blog } = Astro.props as { blog: Blog };
       <div class="bg-white dark:bg-darkCard">
         <div
           class="relative mt-3.5 text-xl md:text-2xl font-bold tracking-tighter max-md:max-w-full text-bluePrimary dark:text-darkText"
-          transition:name={`blog-title-${blog.id}`}
+          transition:name={`blog-title-${slug}`}
         >
           {blog.data.title}
         </div>

--- a/src/components/CardStackable.astro
+++ b/src/components/CardStackable.astro
@@ -6,6 +6,7 @@ import FormattedDate from "./FormattedDate.astro";
 type Blog = CollectionEntry<"blog">;
 
 const { blog } = Astro.props as { blog: Blog };
+const slug = blog.id.replace(/\.mdx?$/, "");
 ---
 
 <CardWrapper class="py-4 px-7 gap-1 w-full">
@@ -18,7 +19,7 @@ const { blog } = Astro.props as { blog: Blog };
           {blog.data.tags[0]}
         </span>
       </div>
-      <a href={`/blog/${blog.id}`}>
+      <a href={`/blog/${slug}`}>
         <h3 class="text-2xl font-bold mt-2 dark:text-darkText">{blog.data.title}</h3>
       </a>
       <p class="text-base text-textPrimary dark:text-darkTextSecondary">
@@ -31,7 +32,7 @@ const { blog } = Astro.props as { blog: Blog };
           style="opacity: 1; transform: translate3d(0%, 0%, 0px) scale3d(1, 1, 1) rotateX(0deg) rotateY(0deg) rotateZ(0deg) skew(0deg, 0deg); transform-style: preserve-3d;"
           class="w-embed"
         >
-          <a href={`/blog/${blog.id}`}>
+          <a href={`/blog/${slug}`}>
             <svg
               width="48"
               height="48"

--- a/src/components/otr/OTRCard.astro
+++ b/src/components/otr/OTRCard.astro
@@ -11,9 +11,10 @@ const { post } = Astro.props;
 const columnist = await getAuthorBySlug(post.data.author);
 const columnName = post.data.column || columnist?.columnName || "Column";
 const prefix = Astro.locals.isColumns ? "" : "/otr";
+const slug = post.id.replace(/\.mdx?$/, "");
 ---
 
-<a href={`${prefix}/posts/${post.id}`} class="block group">
+<a href={`${prefix}/posts/${slug}`} class="block group">
   <div class="rounded-2xl overflow-hidden bg-cardBg border border-cardBorder dark:bg-darkCard dark:border-darkBorder transition-colors hover:border-bluePrimary dark:hover:border-darkAccent">
     <div
       class="aspect-video bg-cover bg-center"

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -18,7 +18,7 @@ export async function getStaticPaths() {
   const blogEntries = await getCollection("blog");
   const featuredBlogs = blogEntries.filter((entry) => entry.data.featured);
   return blogEntries.map((blog) => ({
-    params: { slug: blog.id },
+    params: { slug: blog.id.replace(/\.mdx?$/, "") },
     props: { blog, featuredBlogs: featuredBlogs.filter((b) => b.id !== blog.id).slice(0, 2) },
   }));
 }
@@ -29,6 +29,7 @@ const { blog, featuredBlogs } = Astro.props as {
   featuredBlogs: BlogEntry[];
 };
 const { Content } = await blog.render();
+const slug = blog.id.replace(/\.mdx?$/, "");
 ---
 
 <!doctype html>
@@ -45,12 +46,12 @@ const { Content } = await blog.render();
           style={{
             backgroundImage: `linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8)), url(${blog.data.image.url})`,
           }}
-          transition:name={`blog-card-${blog.id}`}
+          transition:name={`blog-card-${slug}`}
         >
           <div class="max-w-[900px] space-y-4">
             <p class="text-green-300 text-sm font-medium">{blog.data.series}</p>
             <h1
-              transition:name={`blog-title-${blog.id}`}
+              transition:name={`blog-title-${slug}`}
               class="text-white text-3xl sm:text-5xl font-bold"
             >
               {blog.data.title}

--- a/src/pages/otr/posts/[slug].astro
+++ b/src/pages/otr/posts/[slug].astro
@@ -10,7 +10,7 @@ import { getTagLabel } from "@/data/tags";
 
 const { slug } = Astro.params;
 const allEntries = await getCollection("otr");
-const post = allEntries.find((p) => p.id === slug);
+const post = allEntries.find((p) => p.id.replace(/\.mdx?$/, "") === slug);
 
 if (!post) {
   return Astro.redirect("/");

--- a/src/pages/portfolio/[slug].astro
+++ b/src/pages/portfolio/[slug].astro
@@ -15,7 +15,7 @@ export const prerender = true;
 export async function getStaticPaths() {
   const PortfolioEntries = await getCollection("portfolio");
   return PortfolioEntries.map((entry) => ({
-    params: { slug: entry.id },
+    params: { slug: entry.id.replace(/\.mdx?$/, "") },
     props: { entry },
   }));
 }
@@ -27,6 +27,7 @@ type Props = {
 // 2. For your template, you can get the entry directly from the prop
 const { entry } = Astro.props;
 const { Content } = await entry.render();
+const slug = entry.id.replace(/\.mdx?$/, "");
 ---
 
 <!doctype html>
@@ -42,7 +43,7 @@ const { Content } = await entry.render();
           <CardWrapper class="h-full">
             <div class="py-6">
               <h2
-                transition:name={`portfilio-title-${entry.id}`}
+                transition:name={`portfilio-title-${slug}`}
                 class="text-bluePrimary text-3xl font-bold mb-2 dark:text-darkText"
               >
                 {entry.data.title}
@@ -60,7 +61,7 @@ const { Content } = await entry.render();
                 src={entry.data.image.url}
                 alt={entry.data.title}
                 class="w-full h-auto aspect-video md:aspect-[11/5] rounded-3xl mt-6"
-                transition:name={`portfilio-image-${entry.id}`}
+                transition:name={`portfilio-image-${slug}`}
               />
             </div>
           </CardWrapper>

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -46,14 +46,16 @@ const portfolios = await getCollection("portfolio", ({ data }) => {
         </div>
         <div class="space-y-4">
           {
-            portfolios.map((portfolio, index) => (
-              <CardWrapper class="h-full" key={portfolio.id}>
+            portfolios.map((portfolio, index) => {
+              const slug = portfolio.id.replace(/\.mdx?$/, "");
+              return (
+              <CardWrapper class="h-full" key={slug}>
                 <div class="py-6 grid md:grid-cols-2 items-center space-y-12 md:space-y-0">
                   <div
                     class={`${(index + 1) % 2 ? "" : "md:col-start-2"} space-y-4`}
                   >
                     <h2
-                      transition:name={`portfilio-title-${portfolio.id}`}
+                      transition:name={`portfilio-title-${slug}`}
                       class="text-bluePrimary text-3xl font-bold dark:text-darkText"
                     >
                       {portfolio.data.title}
@@ -63,7 +65,7 @@ const portfolios = await getCollection("portfolio", ({ data }) => {
                     </p>
                     <div class="">
                       <a
-                        href={`/portfolio/${portfolio.id}`}
+                        href={`/portfolio/${slug}`}
                         class="text-center py-3 rounded-lg bg-bluePrimary text-white text-sm font-medium px-10 dark:bg-darkAccent dark:text-darkBg"
                       >
                         View Project
@@ -77,12 +79,12 @@ const portfolios = await getCollection("portfolio", ({ data }) => {
                       src={portfolio.data.image.url}
                       alt={portfolio.data.title}
                       class="w-full h-auto object-cover aspect-video rounded-[20px]"
-                      transition:name={`portfilio-image-${portfolio.id}`}
+                      transition:name={`portfilio-image-${slug}`}
                     />
                   </div>
                 </div>
               </CardWrapper>
-            ))
+            )})
           }
         </div>
         <Footer />

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -10,7 +10,7 @@ export async function GET(context) {
     site: context.site,
     items: posts.map((post) => ({
       ...post.data,
-      link: `/blog/${post.id}/`,
+      link: `/blog/${post.id.replace(/\.mdx?$/, "")}/`,
     })),
   });
 }


### PR DESCRIPTION
## Summary

- Fixes 404 errors on OTR posts and other content pages caused by `.mdx` extension in URLs
- In Astro 5, `entry.id` includes the file extension, unlike the old `entry.slug`
- URLs like `/posts/my-post.mdx` now correctly resolve to `/posts/my-post`

## Changes

- Strip `.mdx?` extension when generating URL params in `getStaticPaths()`
- Strip extension when generating `href` links in card components
- Strip extension when matching slugs in dynamic OTR routes
- Update `transition:name` attributes to use stripped slugs for View Transitions

## Files affected

- `src/components/BlogCard.astro`
- `src/components/CardStackable.astro`
- `src/components/otr/OTRCard.astro`
- `src/pages/blog/[slug].astro`
- `src/pages/otr/posts/[slug].astro`
- `src/pages/portfolio/[slug].astro`
- `src/pages/portfolio/index.astro`
- `src/pages/rss.xml.js`

## Test plan

- [ ] Visit OTR hub at `otr.herrerake.com` and click post links
- [ ] Verify blog post links work from `/blog`
- [ ] Verify portfolio links work from `/portfolio`
- [ ] Check View Transitions animate correctly between list and detail pages

🤖 Generated with [Claude Code](https://claude.ai/code)