### PR TITLE
Update navigation and add new pages

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,16 +11,24 @@ const links = [
     location: "/",
   },
   {
-    name: "About me",
+    name: "About",
     location: "/about",
   },
-  // {
-  //   name: "Portfolio",
-  //   location: "/portfolio",
-  // },
   {
     name: "Blog",
     location: "/blog",
+  },
+  {
+    name: "Photography",
+    location: "/photography",
+  },
+  {
+    name: "Projects",
+    location: "/projects",
+  },
+  {
+    name: "Partner",
+    location: "/partner",
   },
   {
     name: "OTR",
@@ -31,7 +39,7 @@ const links = [
 
 <header class="my-4 w-full">
   <CardWrapper class="w-full">
-    <nav class="flex flex-col md:flex-row items-center justify-between">
+    <nav class="flex flex-col items-center lg:flex-row lg:justify-between">
       <h2>
         <a href="/">
           <img
@@ -43,7 +51,7 @@ const links = [
           /></a
         >
       </h2>
-      <div class="flex items-center space-x-4 sm:space-x-8 mt-4 md:mt-1">
+      <div class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 mt-4 lg:mt-0">
         {
           links.map((link) => (
             <HeaderLink href={link.location}>
@@ -56,6 +64,7 @@ const links = [
     </nav>
   </CardWrapper>
 </header>
+
 <style>
   h2 {
     margin: 0;
@@ -72,6 +81,5 @@ const links = [
   }
   nav a.active {
     text-decoration: none;
-    /* border-bottom-color: var(--accent); */
   }
 </style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -2,16 +2,14 @@
 ---
 
 <button
-  id="theme-toggle"
   type="button"
-  class="p-2 rounded-lg text-gray-500 hover:bg-gray-100 dark:text-darkTextSecondary dark:hover:bg-darkCard transition-colors"
+  class="theme-toggle p-2 rounded-lg text-gray-500 hover:bg-gray-100 dark:text-darkTextSecondary dark:hover:bg-darkCard transition-colors"
   aria-label="Toggle dark mode"
   aria-pressed="false"
 >
   <!-- Sun icon (shown in dark mode) -->
   <svg
-    id="sun-icon"
-    class="hidden w-5 h-5"
+    class="theme-sun hidden w-5 h-5"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -26,8 +24,7 @@
   </svg>
   <!-- Moon icon (shown in light mode) -->
   <svg
-    id="moon-icon"
-    class="w-5 h-5"
+    class="theme-moon w-5 h-5"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -47,42 +44,43 @@
   window.__herrerake = window.__herrerake || {};
 
   function setupThemeToggle() {
-    const themeToggle = document.getElementById("theme-toggle");
-    const sunIcon = document.getElementById("sun-icon");
-    const moonIcon = document.getElementById("moon-icon");
+    var toggles = document.querySelectorAll(".theme-toggle");
+    if (!toggles.length) return;
 
-    if (!themeToggle || !sunIcon || !moonIcon) return;
-
-    function updateIcons() {
-      const isDark = document.documentElement.classList.contains("dark");
-      if (isDark) {
-        sunIcon.classList.remove("hidden");
-        moonIcon.classList.add("hidden");
-      } else {
-        sunIcon.classList.add("hidden");
-        moonIcon.classList.remove("hidden");
-      }
-      // Update aria-pressed for accessibility
-      themeToggle.setAttribute("aria-pressed", isDark ? "true" : "false");
+    function updateAllIcons() {
+      var isDark = document.documentElement.classList.contains("dark");
+      toggles.forEach(function (btn) {
+        var sun = btn.querySelector(".theme-sun");
+        var moon = btn.querySelector(".theme-moon");
+        if (sun && moon) {
+          if (isDark) {
+            sun.classList.remove("hidden");
+            moon.classList.add("hidden");
+          } else {
+            sun.classList.add("hidden");
+            moon.classList.remove("hidden");
+          }
+        }
+        btn.setAttribute("aria-pressed", isDark ? "true" : "false");
+      });
     }
 
     function toggleTheme() {
-      const isDark = document.documentElement.classList.toggle("dark");
+      var isDark = document.documentElement.classList.toggle("dark");
       localStorage.setItem("theme", isDark ? "dark" : "light");
-      updateIcons();
-      // Dispatch custom event for other components (e.g., ticker) to react
-      window.dispatchEvent(new CustomEvent("themechange", { detail: { isDark } }));
+      updateAllIcons();
+      window.dispatchEvent(new CustomEvent("themechange", { detail: { isDark: isDark } }));
     }
 
-    // Initialize icons based on current state
-    updateIcons();
+    updateAllIcons();
 
-    // Properly remove existing listener by storing reference on element
-    if (themeToggle._toggleHandler) {
-      themeToggle.removeEventListener("click", themeToggle._toggleHandler);
-    }
-    themeToggle._toggleHandler = toggleTheme;
-    themeToggle.addEventListener("click", toggleTheme);
+    toggles.forEach(function (btn) {
+      if (btn._toggleHandler) {
+        btn.removeEventListener("click", btn._toggleHandler);
+      }
+      btn._toggleHandler = toggleTheme;
+      btn.addEventListener("click", toggleTheme);
+    });
   }
 
   // Run on initial load
@@ -96,7 +94,7 @@
     window.__herrerake.themeMediaListenerAttached = true;
     window
       .matchMedia("(prefers-color-scheme: dark)")
-      .addEventListener("change", (e) => {
+      .addEventListener("change", function (e) {
         if (!localStorage.getItem("theme")) {
           if (e.matches) {
             document.documentElement.classList.add("dark");

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -55,7 +55,7 @@ const aboutMePageContent = {
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title="About Me" description="Background" />
+    <BaseHead title="About" description="Background" />
   </head>
 
   <body>
@@ -68,7 +68,7 @@ const aboutMePageContent = {
           >
             <div class="flex-1 mt-8 lg:mt-0 max-w-[630px]">
               <h1 class="text-bluePrimary text-3xl md:text-4xl font-bold mb-4 dark:text-darkText">
-                About Me
+                About
               </h1>
               <p
                 class="text-xl md:text-2xl leading-7 font-bold text-textPrimary dark:text-darkTextSecondary"

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -45,7 +45,7 @@ const experienceList = [
   },
 ];
 
-const aboutMePageContent = {
+const aboutPageContent = {
   summary: "I'm Kevin Herrera. Software engineer at Cloudflare. Based in Austin, Texas. I build AI agents and production systems that replace manual workflows with reliable intelligent automation. Colombian-American. Fluent in English and Spanish, I work well across cultures and teams, something I picked up growing up between two cultures. When I'm not shipping code, I'm probably walking my dog Miko or making arepas.",
   education: "Graduated from Virginia Commonwealth University in 2014 with a B.A. in History and a minor in Economics. The plan was law school. Worked a few paralegal jobs and realized pretty quickly that wasn't it. In 2016 I enrolled in General Assembly's Web Development Immersive in Washington, DC. That changed everything.",
   experience: "I've worked retail, hospitality, and office administration jobs. All of it taught me how to work with people and figure things out fast. Then I got into engineering — AVIXA, Accruent, and now Cloudflare. Each role pushed me further into building production systems at scale. That's where I found my lane."
@@ -72,7 +72,7 @@ const aboutMePageContent = {
               </h1>
               <p
                 class="text-xl md:text-2xl leading-7 font-bold text-textPrimary dark:text-darkTextSecondary"
-              > {aboutMePageContent.summary}
+              > {aboutPageContent.summary}
               </p>
             </div>
             <div class="max-w-sm w-full">
@@ -98,7 +98,7 @@ const aboutMePageContent = {
                   Education
                 </h2>
                 <p class="text-textPrimary text-xl leading-6 dark:text-darkTextSecondary">
-                  {aboutMePageContent.education}
+                  {aboutPageContent.education}
                 </p>
                 <div class="grid sm:grid-cols-2 gap-6 mt-8">
                   {
@@ -140,7 +140,7 @@ const aboutMePageContent = {
                   Experience
                 </h2>
                 <p class="text-textPrimary text-xl leading-6 dark:text-darkTextSecondary">
-                  {aboutMePageContent.experience}
+                  {aboutPageContent.experience}
                 </p>
                 <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-1 mt-8">
                   {

--- a/src/pages/partner.astro
+++ b/src/pages/partner.astro
@@ -1,0 +1,32 @@
+---
+import BaseHead from "@/components/BaseHead.astro";
+import CardWrapper from "@/components/CardWrapper.astro";
+import Footer from "@/components/Footer.astro";
+import Header from "@/components/Header.astro";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title="Partner" description="Let's work together." />
+  </head>
+
+  <body>
+    <section class="my-8 max-w-[1240px] w-full mx-auto px-4">
+      <Header />
+      <div class="w-full">
+        <CardWrapper class="w-full my-4">
+          <div class="py-12">
+            <h1 class="text-bluePrimary text-3xl md:text-4xl font-bold mb-4 dark:text-darkText">
+              Partner
+            </h1>
+            <p class="text-xl leading-7 text-textPrimary dark:text-darkTextSecondary">
+              Coming soon.
+            </p>
+          </div>
+        </CardWrapper>
+      </div>
+      <Footer />
+    </section>
+  </body>
+</html>

--- a/src/pages/photography.astro
+++ b/src/pages/photography.astro
@@ -1,0 +1,32 @@
+---
+import BaseHead from "@/components/BaseHead.astro";
+import CardWrapper from "@/components/CardWrapper.astro";
+import Footer from "@/components/Footer.astro";
+import Header from "@/components/Header.astro";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title="Photography" description="Photos and visual stories." />
+  </head>
+
+  <body>
+    <section class="my-8 max-w-[1240px] w-full mx-auto px-4">
+      <Header />
+      <div class="w-full">
+        <CardWrapper class="w-full my-4">
+          <div class="py-12">
+            <h1 class="text-bluePrimary text-3xl md:text-4xl font-bold mb-4 dark:text-darkText">
+              Photography
+            </h1>
+            <p class="text-xl leading-7 text-textPrimary dark:text-darkTextSecondary">
+              Coming soon.
+            </p>
+          </div>
+        </CardWrapper>
+      </div>
+      <Footer />
+    </section>
+  </body>
+</html>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,32 @@
+---
+import BaseHead from "@/components/BaseHead.astro";
+import CardWrapper from "@/components/CardWrapper.astro";
+import Footer from "@/components/Footer.astro";
+import Header from "@/components/Header.astro";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title="Projects" description="Things I've built." />
+  </head>
+
+  <body>
+    <section class="my-8 max-w-[1240px] w-full mx-auto px-4">
+      <Header />
+      <div class="w-full">
+        <CardWrapper class="w-full my-4">
+          <div class="py-12">
+            <h1 class="text-bluePrimary text-3xl md:text-4xl font-bold mb-4 dark:text-darkText">
+              Projects
+            </h1>
+            <p class="text-xl leading-7 text-textPrimary dark:text-darkTextSecondary">
+              Coming soon.
+            </p>
+          </div>
+        </CardWrapper>
+      </div>
+      <Footer />
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Renamed "About me" to "About" in nav and on the about page
- Added new nav links and placeholder pages: Photography, Projects, Partner
- Responsive header: logo-left/links-right on desktop, centered stacked with wrapping on mobile/tablet
- Fixed ThemeToggle to use class selectors instead of IDs, supporting multiple instances

## Test plan
- [ ] Verify all nav links route to correct pages on desktop and mobile
- [ ] Resize browser to confirm responsive layout (inline on lg+, stacked/wrapped below)
- [ ] Toggle dark mode on desktop and mobile viewports
- [ ] Check View Transitions don't break theme toggle state

🤖 Generated with [Claude Code](https://claude.com/claude-code)